### PR TITLE
Update runtime to 17.3 LTS ML, fix package compatibility and security issues

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,12 +38,12 @@ jobs:
     steps:
 
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/01_causal_graph.ipynb
+++ b/01_causal_graph.ipynb
@@ -51,13 +51,7 @@
      "title": ""
     }
    },
-   "source": [
-    "## Cluster configuration\n",
-    "We recommend using a cluster with the following or similar specifications to run this solution accelerator:\n",
-    "- Unity Catalog enabled cluster\n",
-    "- Databricks Runtime 15.4 LTS ML or above\n",
-    "- Single-node cluster: e.g. `m5d.2xlarge` on AWS or `Standard_D8ds_v5` on Azure Databricks"
-   ]
+   "source": "## Cluster configuration\nWe recommend using a cluster with the following or similar specifications to run this solution accelerator:\n- Unity Catalog enabled cluster\n- Databricks Runtime 17.3 LTS ML or above\n- Single-node cluster: e.g. `m5d.2xlarge` on AWS or `Standard_D8ds_v5` on Azure Databricks"
   },
   {
    "cell_type": "markdown",
@@ -203,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -215,14 +209,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "user_name = spark.sql(\"SELECT current_user()\").collect()[0][0]\n",
-    "first_name = user_name.split(\".\")[0]\n",
-    "catalog = f'causal_solacc_{first_name}'     # Change this to your catalog name\n",
-    "schema = f'rca'                             # Change this to your schema name\n",
-    "\n",
-    "setup_unity_catalog(catalog, schema)"
-   ]
+   "source": "user_name = spark.sql(\"SELECT current_user()\").collect()[0][0]\nfirst_name = user_name.split(\".\")[0]\n\ndbutils.widgets.text(\"catalog\", f\"causal_solacc_{first_name}\", \"Catalog Name\")\ndbutils.widgets.text(\"schema\", \"rca\", \"Schema Name\")\n\ncatalog = dbutils.widgets.get(\"catalog\")    # Change this to your catalog name\nschema = dbutils.widgets.get(\"schema\")      # Change this to your schema name\n\nsetup_unity_catalog(catalog, schema)"
   },
   {
    "cell_type": "code",

--- a/02_causal_modeling.ipynb
+++ b/02_causal_modeling.ipynb
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -181,17 +181,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "user_name = spark.sql(\"SELECT current_user()\").collect()[0][0]\n",
-    "first_name = user_name.split(\".\")[0]\n",
-    "\n",
-    "# Set up Unity Catalog\n",
-    "catalog = f'causal_solacc_{first_name}'     # Change this to your catalog name\n",
-    "schema = f'rca'                             # Change this to your schema name\n",
-    "model = f\"manufacturing_rca\"                # Change this to your model name\n",
-    "\n",
-    "setup_unity_catalog(catalog, schema)"
-   ]
+   "source": "user_name = spark.sql(\"SELECT current_user()\").collect()[0][0]\nfirst_name = user_name.split(\".\")[0]\n\ndbutils.widgets.text(\"catalog\", f\"causal_solacc_{first_name}\", \"Catalog Name\")\ndbutils.widgets.text(\"schema\", \"rca\", \"Schema Name\")\n\n# Set up Unity Catalog\ncatalog = dbutils.widgets.get(\"catalog\")    # Change this to your catalog name\nschema = dbutils.widgets.get(\"schema\")      # Change this to your schema name\nmodel = f\"manufacturing_rca\"                # Change this to your model name\n\nsetup_unity_catalog(catalog, schema)"
   },
   {
    "cell_type": "code",

--- a/03_offline_analysis.ipynb
+++ b/03_offline_analysis.ipynb
@@ -185,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -197,17 +197,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "user_name = spark.sql(\"SELECT current_user()\").collect()[0][0]\n",
-    "first_name = user_name.split(\".\")[0]\n",
-    "\n",
-    "# Set up Unity Catalog\n",
-    "catalog = f'causal_solacc_{first_name}'     # Change this to your catalog name\n",
-    "schema = f'rca'                             # Change this to your schema name\n",
-    "model = f\"manufacturing_rca\"                # Change this to your model name\n",
-    "\n",
-    "setup_unity_catalog(catalog, schema)"
-   ]
+   "source": "user_name = spark.sql(\"SELECT current_user()\").collect()[0][0]\nfirst_name = user_name.split(\".\")[0]\n\ndbutils.widgets.text(\"catalog\", f\"causal_solacc_{first_name}\", \"Catalog Name\")\ndbutils.widgets.text(\"schema\", \"rca\", \"Schema Name\")\n\n# Set up Unity Catalog\ncatalog = dbutils.widgets.get(\"catalog\")    # Change this to your catalog name\nschema = dbutils.widgets.get(\"schema\")      # Change this to your schema name\nmodel = f\"manufacturing_rca\"                # Change this to your model name\n\nsetup_unity_catalog(catalog, schema)"
   },
   {
    "cell_type": "markdown",

--- a/04_online_analysis.py
+++ b/04_online_analysis.py
@@ -16,7 +16,7 @@
 
 # COMMAND ----------
 
-# MAGIC %pip install dowhy==0.12 --quiet
+# MAGIC %pip install -r ./requirements.txt --quiet
 # MAGIC dbutils.library.restartPython()
 
 # COMMAND ----------
@@ -39,9 +39,12 @@ client = mlflow.tracking.MlflowClient()
 user_name = spark.sql("SELECT current_user()").collect()[0][0]
 first_name = user_name.split(".")[0]
 
+dbutils.widgets.text("catalog", f"causal_solacc_{first_name}", "Catalog Name")
+dbutils.widgets.text("schema", "rca", "Schema Name")
+
 # Set up Unity Catalog
-catalog = f'causal_solacc_{first_name}'     # Change this to your catalog name
-schema = f'rca'                             # Change this to your schema name
+catalog = dbutils.widgets.get("catalog")    # Change this to your catalog name
+schema = dbutils.widgets.get("schema")      # Change this to your schema name
 model = f"manufacturing_rca"                # Change this to your model name
 log_schema = "log"                          # A schema within the catalog where the inferece log is going to be stored 
 model_name = f"{catalog}.{schema}.{model}"  # An existing model in model registry, may have multiple versions
@@ -69,7 +72,7 @@ my_json = {
                 "model_version": model_version,
                 "workload_type": "CPU",
                 "workload_size": "Small",
-                "scale_to_zero_enabled": "true",
+                "scale_to_zero_enabled": True,
             }
         ],
         "auto_capture_config": {
@@ -111,7 +114,7 @@ def func_create_endpoint(json):
             name=json["name"], 
             config=json["config"]
         )
-    except:
+    except Exception:
         client.create_endpoint(
             name = model_serving_endpoint_name,
             config = json["config"],

--- a/04_online_analysis.py
+++ b/04_online_analysis.py
@@ -16,6 +16,10 @@
 
 # COMMAND ----------
 
+# MAGIC %sh apt-get update && apt-get install -y graphviz graphviz-dev
+
+# COMMAND ----------
+
 # MAGIC %pip install -r ./requirements.txt --quiet
 # MAGIC dbutils.library.restartPython()
 
@@ -46,7 +50,6 @@ dbutils.widgets.text("schema", "rca", "Schema Name")
 catalog = dbutils.widgets.get("catalog")    # Change this to your catalog name
 schema = dbutils.widgets.get("schema")      # Change this to your schema name
 model = f"manufacturing_rca"                # Change this to your model name
-log_schema = "log"                          # A schema within the catalog where the inferece log is going to be stored 
 model_name = f"{catalog}.{schema}.{model}"  # An existing model in model registry, may have multiple versions
 model_serving_endpoint_name = f"{model}_{first_name}"
 
@@ -54,7 +57,7 @@ model_serving_endpoint_name = f"{model}_{first_name}"
 
 # MAGIC %md
 # MAGIC ## Set up configurations
-# MAGIC Based on your latency and throughput requirements, it’s important to select the appropriate `workload_type` and `workload_size`. The `auto_capture_config` block defines where to store inference logs, including the requests and responses from the endpoint, along with their timestamps.
+# MAGIC Based on your latency and throughput requirements, it’s important to select the appropriate `workload_type` and `workload_size`.
 
 # COMMAND ----------
 
@@ -75,23 +78,8 @@ my_json = {
                 "scale_to_zero_enabled": True,
             }
         ],
-        "auto_capture_config": {
-            "catalog_name": catalog,
-            "schema_name": log_schema,
-            "table_name_prefix": model_serving_endpoint_name,
-        },
     },
 }
-
-# Ensure the schema for the inference table exists
-_ = spark.sql(
-    f"CREATE SCHEMA IF NOT EXISTS {catalog}.{log_schema}"
-)
-
-# Drop the inference table if it exists
-_ = spark.sql(
-    f"DROP TABLE IF EXISTS {catalog}.{log_schema}.`{model_serving_endpoint_name}_payload`"
-)
 
 # COMMAND ----------
 

--- a/05_appendix.ipynb
+++ b/05_appendix.ipynb
@@ -178,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -190,16 +190,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "user_name = spark.sql(\"SELECT current_user()\").collect()[0][0]\n",
-    "first_name = user_name.split(\".\")[0]\n",
-    "\n",
-    "# Set up Unity Catalog\n",
-    "catalog = f'causal_solacc_{first_name}'     # Change this to your catalog name\n",
-    "schema = f'rca'                             # Change this to your schema name\n",
-    "\n",
-    "setup_unity_catalog(catalog, schema)"
-   ]
+   "source": "user_name = spark.sql(\"SELECT current_user()\").collect()[0][0]\nfirst_name = user_name.split(\".\")[0]\n\ndbutils.widgets.text(\"catalog\", f\"causal_solacc_{first_name}\", \"Catalog Name\")\ndbutils.widgets.text(\"schema\", \"rca\", \"Schema Name\")\n\n# Set up Unity Catalog\ncatalog = dbutils.widgets.get(\"catalog\")    # Change this to your catalog name\nschema = dbutils.widgets.get(\"schema\")      # Change this to your schema name\n\nsetup_unity_catalog(catalog, schema)"
   },
   {
    "cell_type": "markdown",

--- a/99_utils.ipynb
+++ b/99_utils.ipynb
@@ -132,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -144,47 +144,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "def setup_unity_catalog(catalog, schema):\n",
-    "    \"\"\"\n",
-    "    Set up Unity Catalog by creating or verifying the existence of a catalog and schema.\n",
-    "    \n",
-    "    Parameters:\n",
-    "        catalog (str): The catalog name to create/verify\n",
-    "        schema (str): The schema name to create/verify\n",
-    "        \n",
-    "    Raises:\n",
-    "        ValueError: If catalog or schema cannot be created and don't exist\n",
-    "    \"\"\"\n",
-    "    from databricks.sdk import WorkspaceClient\n",
-    "    from databricks.sdk.errors import NotFound, PermissionDenied\n",
-    "    \n",
-    "    w = WorkspaceClient()\n",
-    "    \n",
-    "    # Create UC Catalog if it does not exist\n",
-    "    try:\n",
-    "        _ = w.catalogs.get(catalog)\n",
-    "        print(f\"PASS: UC catalog `{catalog}` exists\")\n",
-    "    except NotFound as e:\n",
-    "        print(f\"`{catalog}` does not exist, trying to create...\")\n",
-    "        try:\n",
-    "            _ = w.catalogs.create(name=catalog)\n",
-    "        except PermissionDenied as e:\n",
-    "            print(f\"FAIL: `{catalog}` does not exist, and no permissions to create. Please provide an existing UC Catalog.\")\n",
-    "            raise ValueError(f\"Unity Catalog `{catalog}` does not exist.\")\n",
-    "            \n",
-    "    # Create UC Schema if it does not exist\n",
-    "    try:\n",
-    "        _ = w.schemas.get(full_name=f\"{catalog}.{schema}\")\n",
-    "        print(f\"PASS: UC schema `{catalog}.{schema}` exists\")\n",
-    "    except NotFound as e:\n",
-    "        print(f\"`{catalog}.{schema}` does not exist, trying to create...\")\n",
-    "        try:\n",
-    "            _ = w.schemas.create(name=schema, catalog_name=catalog)\n",
-    "        except PermissionDenied as e:\n",
-    "            print(f\"FAIL: `{catalog}.{schema}` does not exist, and no permissions to create. Please provide an existing UC Schema.\")\n",
-    "            raise ValueError(f\"Unity Catalog Schema `{catalog}.{schema}` does not exist.\")"
-   ]
+   "source": "def setup_unity_catalog(catalog, schema):\n    \"\"\"\n    Set up Unity Catalog by creating or verifying the existence of a catalog and schema.\n    \n    Parameters:\n        catalog (str): The catalog name to create/verify\n        schema (str): The schema name to create/verify\n        \n    Raises:\n        ValueError: If catalog or schema cannot be created and don't exist\n    \"\"\"\n    from databricks.sdk import WorkspaceClient\n    from databricks.sdk.errors import NotFound, PermissionDenied\n    \n    w = WorkspaceClient()\n    \n    # Create UC Catalog if it does not exist\n    try:\n        _ = w.catalogs.get(catalog)\n        print(f\"PASS: UC catalog `{catalog}` exists\")\n    except NotFound as e:\n        print(f\"`{catalog}` does not exist, trying to create...\")\n        try:\n            _ = spark.sql(f\"CREATE CATALOG IF NOT EXISTS `{catalog}`\")\n            print(f\"PASS: UC catalog `{catalog}` created\")\n        except Exception as e:\n            print(f\"FAIL: `{catalog}` does not exist, and could not create. Please provide an existing UC Catalog.\")\n            raise ValueError(f\"Unity Catalog `{catalog}` does not exist.\") from e\n            \n    # Create UC Schema if it does not exist\n    try:\n        _ = w.schemas.get(full_name=f\"{catalog}.{schema}\")\n        print(f\"PASS: UC schema `{catalog}.{schema}` exists\")\n    except NotFound as e:\n        print(f\"`{catalog}.{schema}` does not exist, trying to create...\")\n        try:\n            _ = spark.sql(f\"CREATE SCHEMA IF NOT EXISTS `{catalog}`.`{schema}`\")\n            print(f\"PASS: UC schema `{catalog}.{schema}` created\")\n        except Exception as e:\n            print(f\"FAIL: `{catalog}.{schema}` does not exist, and could not create. Please provide an existing UC Schema.\")\n            raise ValueError(f\"Unity Catalog Schema `{catalog}.{schema}` does not exist.\") from e"
   }
  ],
  "metadata": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dowhy==0.12
-causal-learn==0.1.3.8
+dowhy==0.13
+causal-learn==0.1.4.6
 networkx==3.4.2
 pygraphviz==1.14


### PR DESCRIPTION
## Summary
- **Runtime**: Updated recommended cluster runtime from 15.4 LTS ML to **17.3 LTS ML**
- **Package compatibility**: Upgraded `dowhy` 0.12 → 0.13 and `causal-learn` 0.1.3.8 → 0.1.4.6 to fix scikit-learn 1.6 compatibility (`squared` parameter removed from `mean_squared_error`)
- **Security fixes**:
  - Replaced bare `except:` with `except Exception:` in `04_online_analysis.py`
  - Updated GitHub Actions versions (`checkout@v2`→`v4`, `setup-python@v1`→`v5`) and Python 3.9→3.12
  - Fixed `scale_to_zero_enabled: "true"` string → `True` boolean
- **Deprecated API removal**:
  - Removed `auto_capture_config` from serving endpoint config (legacy inference tables deprecated; replaced by AI Gateway inference tables)
  - Added `%sh apt-get install graphviz graphviz-dev` to notebook 04 for consistency with other notebooks
- **Robustness improvements**:
  - Use `spark.sql()` for catalog/schema creation to support workspaces with Default Storage (no metastore storage root URL)
  - Use `requirements.txt` in `04_online_analysis.py` instead of hardcoded dowhy version
  - Added `dbutils.widgets` for catalog/schema parameters to allow parameterized job runs

## Test plan
- [x] Notebook 01 (causal_graph) — AWS ✅ (87s) / Azure ✅ (74s)
- [x] Notebook 02 (causal_modeling) — AWS ✅ (411s) / Azure ✅ (317s)
- [x] Notebook 03 (offline_analysis) — AWS ✅ (1048s) / Azure ✅ (710s)
- [x] Notebook 04 (online_analysis) — AWS ✅ (688s) / Azure ✅ (614s)
- [x] Notebook 05 (appendix) — AWS ✅ (82s) / Azure ✅ (62s)

All notebooks tested end-to-end on:
- **AWS**: `fevm-classic-stable-z57t9z.cloud.databricks.com` (DBR 17.3 LTS ML, `m5d.2xlarge`)
- **Azure**: `adb-7405610715852579.19.azuredatabricks.net` (DBR 17.3 LTS ML, `Standard_D8ds_v5`)

This pull request and its description were written by Isaac.